### PR TITLE
refactor: Deprecate MaybeReadOnlyArray and alias to native type

### DIFF
--- a/src/__tests__/MaybeReadOnlyArray.type.test.ts
+++ b/src/__tests__/MaybeReadOnlyArray.type.test.ts
@@ -1,0 +1,33 @@
+export {};
+
+function toWritableArray<Item>(items: readonly Item[]): Item[] {
+  return [
+    ...items,
+  ];
+}
+
+describe('MaybeReadOnlyArray', () => {
+  it('should accept a constant array', () => {
+    const items = [1, 2] as const;
+
+    const mutableArray = toWritableArray(items);
+
+    expect(mutableArray).toStrictEqual(items);
+  });
+
+  it('should accept a read-only array', () => {
+    const items: readonly number[] = [1, 2];
+
+    const mutableArray = toWritableArray(items);
+
+    expect(mutableArray).toStrictEqual(items);
+  });
+
+  it('should accept a writable array', () => {
+    const items = [1, 2];
+
+    const mutableArray = toWritableArray(items);
+
+    expect(mutableArray).toStrictEqual(items);
+  });
+});

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -16,7 +16,8 @@ export type Maybe<T> = T | null | undefined;
 
 export type MaybeNull<T> = T | null;
 
-export type MaybeReadOnlyArray<T> = T[] | ReadonlyArray<T>;
+/* @deprecated Use native `ReadonlyArray` instead; despite its name, it accepts both writable and read-only arrays */
+export type MaybeReadOnlyArray<Item> = ReadonlyArray<Item>;
 
 export type MaybeUndefined<T> = T | undefined;
 


### PR DESCRIPTION
Replaced the custom definition of `MaybeReadOnlyArray` with an alias to the native `ReadonlyArray` type. 

Rationale: Despite its name, the native `ReadonlyArray` type accepts both read-only and writable arrays. Its use is much less problematic than the custom definition.