### PR TITLE
Fix: Url type is typed identically to HttpUrl

### DIFF
--- a/src/pseudo.ts
+++ b/src/pseudo.ts
@@ -13,4 +13,4 @@ export type SortComparison = -1 | 0 | 1;
 
 export type Timestamp = Integer;
 
-export type Url = `http://${string}` | `https://${string}`;
+export type Url = string;


### PR DESCRIPTION
Fixed by reverting the change so that `Url` is again defined as `string`. It should remain so until the use of template-literal types is stabilized.
