### PR TITLE
Add Falsy type as an alias for falsy values

### DIFF
--- a/src/alias.ts
+++ b/src/alias.ts
@@ -3,3 +3,5 @@
 export type AnyRecord = Record<string, any>;
 
 export type EmptyObject = { [key: string]: never; [key: number]: never };
+
+export type Falsy = false | 0 | '' | null | undefined;


### PR DESCRIPTION
Added the `Falsy` type as an alias for the union of all falsy values (false, null, undefined, empty string, and 0).